### PR TITLE
fix(DailyPlanner): use an activity's ID on drop

### DIFF
--- a/client/src/components/DailyPlanner.tsx
+++ b/client/src/components/DailyPlanner.tsx
@@ -223,7 +223,7 @@ function DailyPlanner (props: any, ref: any) {
 
     const activityId = ev.dataTransfer.getData('text');
     // TODO: adapt for Backend when the time comes.
-    const activity = activities.find(a => +a === +activityId);
+    const activity = activities.find(a => +a.id === +activityId);
 
     dispatchDailyActivitiesAction({
       type: 'add',


### PR DESCRIPTION
This addresses these Trello cards:

* [fix: local drag & drop no longer works :(](https://trello.com/c/3WzRamWE)
* [fix: add activity itself after dragging it to "activities"](https://trello.com/c/LNv8v0DC)